### PR TITLE
[CDSR-1412][AO] remove route name collision

### DIFF
--- a/app/uk/gov/hmrc/uploaddocuments/controllers/FileUploadJourneyController.scala
+++ b/app/uk/gov/hmrc/uploaddocuments/controllers/FileUploadJourneyController.scala
@@ -159,7 +159,7 @@ class FileUploadJourneyController @Inject() (
       .applyWithRequest(implicit request => Transitions.toUploadMultipleFiles(preferUploadMultipleFiles))
       .redirectOrDisplayIf[State.UploadMultipleFiles]
 
-  // POST /initialize-upscan/:uploadId
+  // POST /initiate-upscan/:uploadId
   final def initiateNextFileUpload(uploadId: String): Action[AnyContent] =
     whenAuthenticated
       .applyWithRequest { implicit request =>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -16,7 +16,7 @@ GET        /choose-files                                            @uk.gov.hmrc
 GET        /choose-file                                             @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showChooseFile
 
 + nocsrf
-POST       /initialize-upscan/:uploadId                             @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.initiateNextFileUpload(uploadId: String)
+POST       /initiate-upscan/:uploadId                             @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.initiateNextFileUpload(uploadId: String)
 
 GET        /file-rejected                                           @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.markFileUploadAsRejected
 + nocsrf

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/FileUploadJourneyISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/FileUploadJourneyISpec.scala
@@ -333,7 +333,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
       }
     }
 
-    "POST /initialize-upscan/:uploadId" should {
+    "POST /initiate-upscan/:uploadId" should {
       "initialise first file upload" in {
         val state = UploadMultipleFiles(
           FileUploadContext(fileUploadSessionConfig),
@@ -345,7 +345,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
           appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
-        val result = await(request("/initialize-upscan/001").post(""))
+        val result = await(request("/initiate-upscan/001").post(""))
 
         result.status shouldBe 200
         val json = result.body[JsValue]
@@ -415,7 +415,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
           appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
-        val result = await(request("/initialize-upscan/002").post(""))
+        val result = await(request("/initiate-upscan/002").post(""))
 
         result.status shouldBe 200
         val json = result.body[JsValue]


### PR DESCRIPTION
This PR removes route name collision with /initialize which is  not reachable outside an MDTP platform.