### PR TITLE
amend CORS connect rule to allow upscan-proxy redirects when on admin. domain

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -56,7 +56,7 @@ play.filters.csp.directives {
  object-src ="'none'"
  img-src = "'self' localhost:10100 localhost:9032 https://ssl.gstatic.com www.googletagmanager.com www.gstatic.com www.google-analytics.com data:"
  frame-src = "'self' www.googletagmanager.com"
- connect-src = "'self' localhost:10100 localhost:9570 localhost:12345 *.amazonaws.com www.googletagmanager.com www.google-analytics.com tagmanager.google.com *.upscan.tax.service.gov.uk"
+ connect-src = "'self' *.tax.service.gov.uk localhost:10100 localhost:9570 localhost:12345 *.amazonaws.com www.googletagmanager.com www.google-analytics.com tagmanager.google.com *.upscan.tax.service.gov.uk"
 }
 
 play.i18n.langCookieHttpOnly = true


### PR DESCRIPTION
This PR fixes an issue dicovered when running UDF in the admin. domain instead of www.