### PR TITLE
make backchannel routes internal only

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ Reference implementation of the UDF integration can be found in the https://gith
 
 ### Tasks
 
-1. implement a backchannel connector to the UDF calling [`/initialize`](#api-initialize) endpoint and returning link to the upload page,
+1. implement a backchannel connector to the UDF calling [`https://upload-documents-frontend.public.mdtp/internal/initialize`](#api-initialize) endpoint and returning link to the upload page,
 
 2. implement an authenticated backchannel `+nocsrf POST` endpoint for receiving [`UploadedFilesCallbackPayload`](#callback-payload); this will be pushed to the host service every time new file is uploaded or existing removed; UDF will take care of sending proper `Authorization` and `X-Session-ID` headers with the request,
 
 3. use connector (1) each time before you navigate the user to the upload page, send a config and optionally a list of already uploaded files, use returned `Location` header to redirect user to the upload page URL,
 
-4. call [`/wipe-out`](#api-wipe-out) endpoint when you no longer need upload session data, ideally after successful conclusion of the host journey.
+4. call [`https://upload-documents-frontend.public.mdtp/internal/wipe-out`](#api-wipe-out) endpoint when you no longer need upload session data, ideally after successful conclusion of the host journey.
+
+Locally you should use `http://localhost:10100` instead of `https://upload-documents-frontend.public.mdtp`.
 
 <a name="callback-payload"></a>
 ### Callback payload schema
@@ -68,7 +70,9 @@ Reference implementation of the UDF integration can be found in the https://gith
 <a name="api-initialize"></a>
 ### POST /initialize
 
-An endpoint to initialize upload session. Might be invoked multiple times in the same session.
+An internal endpoint to initialize upload session. Might be invoked multiple times in the same session.
+
+Location: `https://upload-documents-frontend.public.mdtp/internal/initialize` or `http://localhost:10100/internal/initialize`
 
 Requires an `Authorization` and `X-Session-ID` headers, usually supplied transparently by the `HeaderCarrier`. 
 
@@ -158,7 +162,9 @@ Minimal payload example:
 <a name="api-wipe-out"></a>
 ### POST /wipe-out
 
-And endpoint to immediately remove upload session data, usually invoked at the end of an encompassing host journey. If not, session data will be removed anyway after the MongoDB cache timeout expires.
+An internal endpoint to immediately remove upload session data, usually invoked at the end of an encompassing host journey. If not, session data will be removed anyway after the MongoDB cache timeout expires.
+
+Location: `https://upload-documents-frontend.public.mdtp/internal/wipe-out` or `http://localhost:10100/internal/wipe-out`
 
 Requires an `Authorization` and `X-Session-ID` headers, usually supplied transparently by the `HeaderCarrier`. 
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,55 +1,55 @@
 # microservice specific routes
 
-->         /hmrc-frontend                                           hmrcfrontend.Routes 
+->         /upload-documents/hmrc-frontend                                           hmrcfrontend.Routes 
 
-GET        /                                                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.start
+GET        /upload-documents/                                                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.start
 
 # backchannel endpoint to (re)initialize documents upload session
 + nocsrf
-POST       /initialize                                              @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.initialize
+POST       /internal/initialize                                                      @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.initialize
 
 # backchannel endpoint to effectively wipe-out current session data
 + nocsrf
-POST       /wipe-out                                                 @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.wipeOut
+POST       /internal/wipe-out                                                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.wipeOut
 
-GET        /choose-files                                            @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showChooseMultipleFiles
-GET        /choose-file                                             @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showChooseFile
+GET        /upload-documents/choose-files                                            @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showChooseMultipleFiles
+GET        /upload-documents/choose-file                                             @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showChooseFile
 
 + nocsrf
-POST       /initiate-upscan/:uploadId                             @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.initiateNextFileUpload(uploadId: String)
+POST       /upload-documents/initiate-upscan/:uploadId                               @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.initiateNextFileUpload(uploadId: String)
 
-GET        /file-rejected                                           @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.markFileUploadAsRejected
+GET        /upload-documents/file-rejected                                           @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.markFileUploadAsRejected
 + nocsrf
-POST       /file-rejected                                           @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.markFileUploadAsRejectedAsync
+POST       /upload-documents/file-rejected                                           @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.markFileUploadAsRejectedAsync
 
-GET        /journey/:journeyId/file-posted                          @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.asyncMarkFileUploadAsPosted(journeyId: String)
-OPTIONS    /journey/:journeyId/file-posted                          @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.preflightUpload(journeyId: String)
-GET        /journey/:journeyId/file-rejected                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.asyncMarkFileUploadAsRejected(journeyId: String)
-OPTIONS    /journey/:journeyId/file-rejected                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.preflightUpload(journeyId: String)
-GET        /journey/:journeyId/file-verification                    @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.asyncWaitingForFileVerification(journeyId: String)
+GET        /upload-documents/journey/:journeyId/file-posted                          @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.asyncMarkFileUploadAsPosted(journeyId: String)
+OPTIONS    /upload-documents/journey/:journeyId/file-posted                          @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.preflightUpload(journeyId: String)
+GET        /upload-documents/journey/:journeyId/file-rejected                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.asyncMarkFileUploadAsRejected(journeyId: String)
+OPTIONS    /upload-documents/journey/:journeyId/file-rejected                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.preflightUpload(journeyId: String)
+GET        /upload-documents/journey/:journeyId/file-verification                    @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.asyncWaitingForFileVerification(journeyId: String)
 
 # backchannel endpoint to receive upscan notification
 + nocsrf
-POST       /callback-from-upscan/journey/:journeyId/:nonce          @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.callbackFromUpscan(journeyId: String, nonce: String)
+POST       /internal/callback-from-upscan/journey/:journeyId/:nonce                  @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.callbackFromUpscan(journeyId: String, nonce: String)
 
-GET        /file-verification                                       @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showWaitingForFileVerification
-GET        /file-verification/:reference/status                     @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.checkFileVerificationStatus(reference: String)
+GET        /upload-documents/file-verification                                       @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showWaitingForFileVerification
+GET        /upload-documents/file-verification/:reference/status                     @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.checkFileVerificationStatus(reference: String)
 
-GET        /summary                                                 @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showSummary
-POST       /summary                                                 @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.submitUploadAnotherFileChoice
-GET        /uploaded/:reference/remove                              @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.removeFileUploadByReference(reference: String)
+GET        /upload-documents/summary                                                 @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.showSummary
+POST       /upload-documents/summary                                                 @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.submitUploadAnotherFileChoice
+GET        /upload-documents/uploaded/:reference/remove                              @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.removeFileUploadByReference(reference: String)
 + nocsrf
-POST       /uploaded/:reference/remove                              @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.removeFileUploadByReferenceAsync(reference: String)
+POST       /upload-documents/uploaded/:reference/remove                              @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.removeFileUploadByReferenceAsync(reference: String)
 
-GET        /preview/:reference/:fileName                            @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.previewFileUploadByReference(reference: String, fileName: String)
+GET        /upload-documents/preview/:reference/:fileName                            @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.previewFileUploadByReference(reference: String, fileName: String)
 
-GET        /continue-to-host                                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.continueToHost
+GET        /upload-documents/continue-to-host                                        @uk.gov.hmrc.uploaddocuments.controllers.FileUploadJourneyController.continueToHost
 
-GET        /timedout                                                @uk.gov.hmrc.uploaddocuments.controllers.SessionController.showTimeoutPage
-GET        /keep-alive                                              @uk.gov.hmrc.uploaddocuments.controllers.SessionController.keepAlive(continueUrl: Option[String] ?= None)
+GET        /upload-documents/timedout                                                @uk.gov.hmrc.uploaddocuments.controllers.SessionController.showTimeoutPage
+GET        /upload-documents/keep-alive                                              @uk.gov.hmrc.uploaddocuments.controllers.SessionController.keepAlive(continueUrl: Option[String] ?= None)
 
-GET        /sign-out                                                @uk.gov.hmrc.uploaddocuments.controllers.SignOutController.signOut(continueUrl: Option[String] ?= None)
-GET        /sign-out/timeout                                        @uk.gov.hmrc.uploaddocuments.controllers.SignOutController.signOutTimeout(continueUrl: Option[String] ?= None)
+GET        /upload-documents/sign-out                                                @uk.gov.hmrc.uploaddocuments.controllers.SignOutController.signOut(continueUrl: Option[String] ?= None)
+GET        /upload-documents/sign-out/timeout                                        @uk.gov.hmrc.uploaddocuments.controllers.SignOutController.signOutTimeout(continueUrl: Option[String] ?= None)
 
-GET        /language/:lang                                          @uk.gov.hmrc.uploaddocuments.controllers.LanguageSwitchController.switchToLanguage(lang: String)
-GET        /assets/*file                                            controllers.Assets.versioned(path="/public", file: Asset)
+GET        /upload-documents/language/:lang                                          @uk.gov.hmrc.uploaddocuments.controllers.LanguageSwitchController.switchToLanguage(lang: String)
+GET        /upload-documents/assets/*file                                            controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,4 +1,4 @@
-->         /upload-documents     app.Routes
+->         /                     app.Routes
 ->         /                     health.Routes
 
 GET        /admin/metrics        @com.kenshoo.play.metrics.MetricsController.metrics

--- a/it/uk/gov/hmrc/uploaddocuments/controllers/FileUploadJourneyISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/controllers/FileUploadJourneyISpec.scala
@@ -89,7 +89,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
       "return 404 if wrong http method" in {
         journey.setState(Uninitialized)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
-        val result = await(request("/initialize").get())
+        val result = await(backchannelRequest("/initialize").get())
         result.status shouldBe 404
         journey.getState shouldBe Uninitialized
       }
@@ -97,7 +97,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
       "return 400 if malformed payload" in {
         journey.setState(Uninitialized)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
-        val result = await(request("/initialize").post(""))
+        val result = await(backchannelRequest("/initialize").post(""))
         result.status shouldBe 400
         journey.getState shouldBe Uninitialized
       }
@@ -106,7 +106,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(Uninitialized)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val result = await(
-          request("/initialize")
+          backchannelRequest("/initialize")
             .post(
               Json.toJson(
                 UploadedFile(
@@ -129,7 +129,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(Uninitialized)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val result = await(
-          request("/initialize")
+          backchannelRequest("/initialize")
             .post(Json.toJson(FileUploadInitializationRequest(fileUploadSessionConfig, Seq.empty)))
         )
         result.status shouldBe 201
@@ -158,7 +158,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(Uninitialized)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val result = await(
-          request("/initialize")
+          backchannelRequest("/initialize")
             .post(
               Json.toJson(
                 FileUploadInitializationRequest(
@@ -190,7 +190,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         )
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
-        val result = await(request("/wipe-out").get())
+        val result = await(backchannelRequest("/wipe-out").get())
         result.status shouldBe 404
         journey.getState shouldBe state
       }
@@ -205,7 +205,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         )
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
-        val result = await(request("/wipe-out").post(""))
+        val result = await(backchannelRequest("/wipe-out").post(""))
         result.status shouldBe 204
         journey.getState shouldBe Uninitialized
       }
@@ -221,7 +221,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(request("/").get())
@@ -263,7 +263,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(request("/choose-files").get())
@@ -342,7 +342,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(request("/initiate-upscan/001").post(""))
@@ -412,7 +412,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(request("/initiate-upscan/002").post(""))
@@ -480,7 +480,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(request("/choose-file").get())
@@ -536,7 +536,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(request("/choose-file").get())
@@ -598,7 +598,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(request("/choose-file").get())
@@ -960,7 +960,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(
@@ -1007,7 +1007,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
         val callbackUrl =
-          appConfig.baseInternalCallbackUrl + s"/upload-documents/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
+          appConfig.baseInternalCallbackUrl + s"/internal/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}"
         givenUpscanInitiateSucceeds(callbackUrl, hostUserAgent)
 
         val result = await(
@@ -1529,7 +1529,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         )
         val result =
           await(
-            requestWithoutSessionId(
+            backchannelRequestWithoutSessionId(
               s"/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}/$nonce"
             )
               .withHttpHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
@@ -1619,7 +1619,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         )
         val result =
           await(
-            requestWithoutSessionId(
+            backchannelRequestWithoutSessionId(
               s"/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}/$nonce"
             )
               .withHttpHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
@@ -1703,7 +1703,7 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         )
         val result =
           await(
-            requestWithoutSessionId(
+            backchannelRequestWithoutSessionId(
               s"/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}/$nonce"
             )
               .withHttpHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
@@ -1765,7 +1765,9 @@ class FileUploadJourneyISpec extends FileUploadJourneyISpecSetup with ExternalAp
         )
         val result =
           await(
-            requestWithoutSessionId(s"/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}/${Nonce.random}")
+            backchannelRequestWithoutSessionId(
+              s"/callback-from-upscan/journey/${SHA256.compute(journeyId.value)}/${Nonce.random}"
+            )
               .withHttpHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
               .post(
                 Json.obj(
@@ -1887,6 +1889,21 @@ trait FileUploadJourneyISpecSetup extends ServerISpec with StateMatchers {
         .encodeAsCookie(Session(Map(SessionKeys.sessionId -> journeyId.value)))
     wsClient
       .url(s"$baseUrl$path")
+      .withCookies(
+        DefaultWSCookie(
+          sessionCookie.name,
+          sessionCookieCrypto.crypto.encrypt(PlainText(sessionCookie.value)).value
+        )
+      )
+      .addHttpHeaders(play.api.http.HeaderNames.USER_AGENT -> "it-test")
+  }
+
+  final def backchannelRequest(path: String)(implicit journeyId: JourneyId): StandaloneWSRequest = {
+    val sessionCookie =
+      sessionCookieBaker
+        .encodeAsCookie(Session(Map(SessionKeys.sessionId -> journeyId.value)))
+    wsClient
+      .url(s"$backchannelBaseUrl$path")
       .withCookies(
         DefaultWSCookie(
           sessionCookie.name,

--- a/it/uk/gov/hmrc/uploaddocuments/support/ServerISpec.scala
+++ b/it/uk/gov/hmrc/uploaddocuments/support/ServerISpec.scala
@@ -32,9 +32,14 @@ abstract class ServerISpec extends BaseISpec with GuiceOneServerPerSuite {
   case class JourneyId(value: String = UUID.randomUUID().toString)
 
   val baseUrl: String = s"http://localhost:$port/upload-documents"
+  val backchannelBaseUrl: String = s"http://localhost:$port/internal"
 
   def requestWithoutSessionId(path: String) =
     wsClient
       .url(s"$baseUrl$path")
+
+  def backchannelRequestWithoutSessionId(path: String) =
+    wsClient
+      .url(s"$backchannelBaseUrl$path")
 
 }


### PR DESCRIPTION
This PR addreses a request to make backchannel routes not visible outside of the platform, specifically to use /internal route prefix instead of /upload-documents.